### PR TITLE
Command item model

### DIFF
--- a/commanditemmodel.cpp
+++ b/commanditemmodel.cpp
@@ -104,14 +104,11 @@ bool CommandItemModel::filterAcceptsRow(int sourceRow, const QModelIndex &source
 
     const CommandProviderItem *item = mSourceModel->command(sourceRow);
 
-    if (!item)
-        return false;
-
-    bool accept = item->compare(re);
+    bool accept = item != nullptr && item->compare(re);
     if (accept)
     {
         //check if CustomCommand can be filtered out (equivalent app link is shown)
-        const CustomCommandItem * cust_i = qobject_cast<const CustomCommandItem *>(item);
+        auto cust_i = qobject_cast<const CustomCommandItem *>(item);
         if (nullptr != cust_i)
         {
             for (int i = mSourceModel->rowCount(sourceParent); 0 <= i; --i)

--- a/commanditemmodel.cpp
+++ b/commanditemmodel.cpp
@@ -141,8 +141,8 @@ bool CommandItemModel::lessThan(const QModelIndex &left, const QModelIndex &righ
     const auto leftItem = mSourceModel->command(left);
     const auto righItem = mSourceModel->command(right);
 
-    HistoryItem const * i_left = dynamic_cast<HistoryItem const *>(leftItem);
-    HistoryItem const * i_right = dynamic_cast<HistoryItem const *>(righItem);
+    auto i_left = qobject_cast<HistoryItem const *>(leftItem);
+    auto i_right = qobject_cast<HistoryItem const *>(righItem);
     if (nullptr != i_left && nullptr == i_right)
         return mShowHistoryFirst;
     if (nullptr == i_left && nullptr != i_right)
@@ -151,8 +151,8 @@ bool CommandItemModel::lessThan(const QModelIndex &left, const QModelIndex &righ
     {
         QRegExp re(filterRegExp());
         //Note: -1 should not be returned if the item passed the filter previously
-        const int pos_left = re.indexIn(i_left->command());
-        const int pos_right = re.indexIn(i_right->command());
+        int pos_left = re.indexIn(i_left->command());
+        int pos_right = re.indexIn(i_right->command());
         Q_ASSERT(-1 != pos_left && -1 != pos_right);
         return pos_left < pos_right
             || (pos_left == pos_right && QSortFilterProxyModel::lessThan(left, right));

--- a/commanditemmodel.cpp
+++ b/commanditemmodel.cpp
@@ -327,7 +327,7 @@ QVariant CommandSourceItemModel::data(const QModelIndex &index, int role) const
     if (index.row() >= rowCount())
         return QVariant();
 
-    const CommandProviderItem *item = command(index);
+    auto item = command(index);
     if (!item)
         return QVariant();
 

--- a/commanditemmodel.cpp
+++ b/commanditemmodel.cpp
@@ -177,10 +177,9 @@ int CommandItemModel::itemType(const QModelIndex &index) const
 {
     if (index.row() == mSourceModel->customCommandIndex().row())
         return 1;
-    else if (index.row() < mSourceModel->externalProviderStartIndex().row())
+    if (index.row() < mSourceModel->externalProviderStartIndex().row())
         return 2;
-    else
-        return 3;
+    return 3;
 }
 
 

--- a/commanditemmodel.h
+++ b/commanditemmodel.h
@@ -41,10 +41,10 @@ class CommandSourceItemModel: public QAbstractListModel
 
 public:
     explicit CommandSourceItemModel(bool useHistory, QObject *parent = 0);
-    virtual ~CommandSourceItemModel();
+    ~CommandSourceItemModel() override;
 
-    int rowCount(const QModelIndex &parent=QModelIndex()) const;
-    QVariant data(const QModelIndex &index, int role=Qt::DisplayRole) const;
+    int rowCount(const QModelIndex &parent=QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role=Qt::DisplayRole) const override;
 
     bool isOutDated() const;
     const CommandProviderItem *command(const QModelIndex &index) const;
@@ -80,7 +80,7 @@ class CommandItemModel: public QSortFilterProxyModel
 
 public:
     explicit CommandItemModel(bool useHistory, QObject *parent = 0);
-    virtual ~CommandItemModel();
+    ~CommandItemModel() override;
 
     bool isOutDated() const;
     const CommandProviderItem *command(const QModelIndex &index) const;
@@ -104,8 +104,8 @@ public slots:
     void clearHistory();
 
 protected:
-    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const;
-    bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+    bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 
 private:
     int itemType(const QModelIndex &index) const;

--- a/mylistview.h
+++ b/mylistview.h
@@ -42,7 +42,7 @@ public:
     }
 
 protected:
-    virtual QSize viewportSizeHint() const override
+    QSize viewportSizeHint() const override
     {
         QAbstractItemModel * m = model();
         if (m == nullptr)

--- a/providers.h
+++ b/providers.h
@@ -51,7 +51,6 @@ class CommandProviderItem: public QObject
 
 public:
     CommandProviderItem(): QObject() {}
-    virtual ~CommandProviderItem() {}
 
     virtual bool run() const = 0;
     virtual bool compare(const QRegExp &regExp) const = 0;
@@ -95,7 +94,7 @@ class CommandProvider: public QObject, public QList<CommandProviderItem*>
 
 public:
     CommandProvider();
-    virtual ~CommandProvider();
+    ~CommandProvider() override;
 
     virtual void rebuild() {}
     virtual bool isOutDated() const { return false; }
@@ -149,7 +148,7 @@ class AppLinkProvider: public CommandProvider
 
 public:
     AppLinkProvider();
-    virtual ~AppLinkProvider();
+    ~AppLinkProvider() override;
 
 private slots:
     void update();
@@ -195,7 +194,7 @@ class HistoryProvider: public CommandProvider
 
 public:
     HistoryProvider();
-    virtual ~HistoryProvider();
+    ~HistoryProvider() override;
 
     void AddCommand(const QString &command);
     void clearHistory();
@@ -218,14 +217,14 @@ class CustomCommandItem: public CommandProviderItem
 public:
     CustomCommandItem(CustomCommandProvider *provider);
 
-    bool run() const;
-    bool compare(const QRegExp &regExp) const;
+    bool run() const override;
+    bool compare(const QRegExp &regExp) const override;
 
     QString command() const { return mCommand; }
     void setCommand(const QString &command);
     QString exec() const { return mExec; }
 
-    virtual unsigned int rank(const QString &pattern) const;
+    unsigned int rank(const QString &pattern) const override;
 private:
     QString mCommand;
     QString mExec; //!< the expanded executable (full path)
@@ -269,9 +268,9 @@ public:
     MathItem();
     ~MathItem();
 
-    bool run() const;
-    bool compare(const QRegExp &regExp) const;
-    virtual unsigned int rank(const QString &pattern) const;
+    bool run() const override;
+    bool compare(const QRegExp &regExp) const override;
+    unsigned int rank(const QString &pattern) const override;
 private:
     QScopedPointer<Parser> mParser;
     mutable QString mCachedInput;
@@ -285,7 +284,7 @@ class MathProvider: public CommandProvider
 
 public:
     MathProvider();
-    //virtual ~MathProvider();
+    //~MathProvider() override;
 };
 #endif
 
@@ -303,9 +302,9 @@ public:
   VirtualBoxItem(const QString & MachineName , const QIcon & Icon);
 
   void setRDEPort (const QString & portNum);
-  bool run() const;
-  bool compare(const QRegExp &regExp) const;
-  virtual unsigned int rank(const QString &pattern) const;
+  bool run() const override;
+  bool compare(const QRegExp &regExp) const override;
+  unsigned int rank(const QString &pattern) const override;
 private:
   QString m_rdePortNum;
 };

--- a/yamlparser.cpp
+++ b/yamlparser.cpp
@@ -38,10 +38,6 @@ YamlParser::YamlParser()
     state = start;
 }
 
-YamlParser::~YamlParser()
-{
-}
-
 void YamlParser::consumeLine(QString line)
 {
     static QRegExp documentStart(QSL("---\\s*(\\[\\]\\s*)?"));

--- a/yamlparser.h
+++ b/yamlparser.h
@@ -40,7 +40,6 @@ class YamlParser : public QObject
     Q_OBJECT
 public:
     YamlParser();
-    virtual ~YamlParser();
 
     void consumeLine(QString line);
 


### PR DESCRIPTION
Followup to #195 -> Little bit of code cleanup:

- fixes virtual overrides & virtual destructors
- replaces dynamic_cast with qobject_cast where suitable
- auto type (const) pointers
- removes const on copied (int) values