### PR TITLE
No redundant writing of dialog width to config file

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -176,9 +176,10 @@ QSize Dialog::sizeHint() const
 /************************************************
 
  ************************************************/
-void Dialog::resizeEvent(QResizeEvent * /*event*/)
+void Dialog::resizeEvent(QResizeEvent *event)
 {
-    mSettings->setValue(QL1S("dialog/width"), size().width());
+    if (event->spontaneous())
+        mSettings->setValue(QL1S("dialog/width"), size().width());
 }
 
 


### PR DESCRIPTION
We need to write the width to the config file only when the resize event is "spontaneous", as Qt calls it.

Closes https://github.com/lxqt/lxqt-runner/issues/205