### PR TITLE
dialog: Force correct position after move from outside of application

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -133,8 +133,6 @@ Dialog::Dialog(QWidget *parent) :
 
     connect(mGlobalShortcut, &GlobalKeyShortcut::Action::activated, this, &Dialog::showHide);
     connect(mGlobalShortcut, &GlobalKeyShortcut::Action::shortcutChanged, this, &Dialog::shortcutChanged);
-    connect(KWindowSystem::self(), &KWindowSystem::activeWindowChanged, this, &Dialog::onActiveWindowChanged);
-    connect(KWindowSystem::self(), &KWindowSystem::currentDesktopChanged, this, &Dialog::onCurrentDesktopChanged);
 
     resize(mSettings->value(QL1S("dialog/width"), 400).toInt(), size().height());
 
@@ -194,6 +192,28 @@ void Dialog::moveEvent(QMoveEvent *event)
     if (event->spontaneous())
         QTimer::singleShot(0, this, &Dialog::realign);
     return QDialog::moveEvent(event);
+}
+
+
+/************************************************
+
+ ************************************************/
+void Dialog::showEvent(QShowEvent *event)
+{
+    connect(KWindowSystem::self(), &KWindowSystem::activeWindowChanged, this, &Dialog::onActiveWindowChanged);
+    connect(KWindowSystem::self(), &KWindowSystem::currentDesktopChanged, this, &Dialog::onCurrentDesktopChanged);
+    return QDialog::showEvent(event);
+}
+
+
+/************************************************
+
+ ************************************************/
+void Dialog::hideEvent(QHideEvent *event)
+{
+    QDialog::hideEvent(event);
+    disconnect(KWindowSystem::self(), &KWindowSystem::currentDesktopChanged, this, &Dialog::onCurrentDesktopChanged);
+    disconnect(KWindowSystem::self(), &KWindowSystem::activeWindowChanged, this, &Dialog::onActiveWindowChanged);
 }
 
 
@@ -397,7 +417,6 @@ void Dialog::applySettings()
     mCommandItemModel->showHistoryFirst(mSettings->value(QL1S("dialog/history_first"), true).toBool());
     ui->commandList->setShownCount(mSettings->value(QL1S("dialog/list_shown_items"), 4).toInt());
 
-    realign();
     mSettings->sync();
 }
 

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -186,6 +186,20 @@ void Dialog::resizeEvent(QResizeEvent *event)
 /************************************************
 
  ************************************************/
+void Dialog::moveEvent(QMoveEvent *event)
+{
+    // Note: For some reason the dialog gets repositioned by "outer world" (VM?) to
+    // wrong position (0,0). The root cause of this move is yet unknown and
+    // this is a workaround to avoid wong position of the window.
+    if (event->spontaneous())
+        QTimer::singleShot(0, this, &Dialog::realign);
+    return QDialog::moveEvent(event);
+}
+
+
+/************************************************
+
+ ************************************************/
 bool Dialog::eventFilter(QObject *object, QEvent *event)
 {
     if (event->type() == QEvent::KeyPress)

--- a/dialog.h
+++ b/dialog.h
@@ -65,6 +65,8 @@ protected:
     void closeEvent(QCloseEvent *event);
     void resizeEvent(QResizeEvent *event);
     void moveEvent(QMoveEvent *event);
+    void showEvent(QShowEvent *event);
+    void hideEvent(QHideEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
     bool editKeyPressEvent(QKeyEvent *event);
     bool listKeyPressEvent(QKeyEvent *event);

--- a/dialog.h
+++ b/dialog.h
@@ -64,6 +64,7 @@ public:
 protected:
     void closeEvent(QCloseEvent *event);
     void resizeEvent(QResizeEvent *event);
+    void moveEvent(QMoveEvent *event);
     bool eventFilter(QObject *object, QEvent *event);
     bool editKeyPressEvent(QKeyEvent *event);
     bool listKeyPressEvent(QKeyEvent *event);


### PR DESCRIPTION
For some reason the dialog get repositioned by "outer world" (VM?) to
wrong position (0,0). The root cause of this move is yet unknown and
this is a workaround to avoid wrong position of the window.

closes #220