### PR TITLE
Added an option for clearing command on running

### DIFF
--- a/configuredialog/configuredialog.cpp
+++ b/configuredialog/configuredialog.cpp
@@ -83,6 +83,7 @@ ConfigureDialog::ConfigureDialog(QSettings *settings, const QString &defaultShor
 
     connect(ui->historyUseCb, &QAbstractButton::toggled, this, [this] (bool checked) { mSettings->setValue(QL1S("dialog/history_use"), checked); });
     connect(ui->historyFirstCb, &QAbstractButton::toggled, this, [this] (bool checked) { mSettings->setValue(QL1S("dialog/history_first"), checked); });
+    connect(ui->clearCb, &QAbstractButton::toggled, this, [this] (bool checked) { mSettings->setValue(QL1S("dialog/clear_on_running"), checked); });
     connect(ui->listShownItemsSB, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, [this] (int i) { mSettings->setValue(QL1S("dialog/list_shown_items"), i); });
 }
 
@@ -103,6 +104,7 @@ void ConfigureDialog::settingsChanged()
     ui->historyUseCb->setChecked(history_use);
     ui->historyFirstCb->setChecked(mSettings->value(QL1S("dialog/history_first"), true).toBool());
     ui->historyFirstCb->setEnabled(history_use);
+    ui->clearCb->setChecked(mSettings->value(QL1S("dialog/clear_on_running"), true).toBool());
     ui->listShownItemsSB->setValue(mSettings->value(QL1S("dialog/list_shown_items"), 4).toInt());
 }
 

--- a/configuredialog/configuredialog.ui
+++ b/configuredialog/configuredialog.ui
@@ -74,6 +74,13 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="clearCb">
+        <property name="text">
+         <string>Clear input on launching</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/dialog.cpp
+++ b/dialog.cpp
@@ -411,6 +411,8 @@ void Dialog::applySettings()
 
     mShowOnTop = mSettings->value(QL1S("dialog/show_on_top"), true).toBool();
 
+    mClearOnRunning = mSettings->value(QL1S("dialog/clear_on_running"), true).toBool();
+
     mMonitor = mSettings->value(QL1S("dialog/monitor"), -1).toInt();
 
     mCommandItemModel->setUseHistory(mSettings->value(QL1S("dialog/history_use"), true).toBool());
@@ -532,8 +534,11 @@ void Dialog::runCommand()
     if (res)
     {
         hide();
-        if (!qobject_cast<const MathItem*>(command)) // don't clear math results
+        if (mClearOnRunning
+            && !qobject_cast<const MathItem*>(command)) // don't clear math results
+        {
             ui->commandEd->clear();
+        }
     }
 
 }

--- a/dialog.h
+++ b/dialog.h
@@ -77,6 +77,7 @@ private:
     GlobalKeyShortcut::Action *mGlobalShortcut;
     CommandItemModel *mCommandItemModel;
     bool mShowOnTop;
+    bool mClearOnRunning;
     int mMonitor;
     LXQt::PowerManager *mPowerManager;
     LXQt::ScreenSaver *mScreenSaver;


### PR DESCRIPTION
LXQt Runner does that without an option. This patch adds an option, keeping the current behavior by default.

Use case: one may use LXQt Runner for running a specific app frequently, while using Main Menu for other apps.