### PR TITLE
Made the window frameless explicitly

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -62,7 +62,7 @@
 
  ************************************************/
 Dialog::Dialog(QWidget *parent) :
-    QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint),
+    QDialog(parent, Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint | Qt::FramelessWindowHint),
     ui(new Ui::Dialog),
     mSettings(new LXQt::Settings(QSL("lxqt-runner"), this)),
     mGlobalShortcut(0),


### PR DESCRIPTION
`Qt::FramelessWindowHint` is needed for making the window frameless under most Wayland compositors.