### PR TITLE
Hide window on deactivation under Wayland

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -556,4 +556,19 @@ void Dialog::showConfigDialog()
     mConfigureDialog->exec();
 }
 
+
+/************************************************
+
+ ************************************************/
+bool Dialog::event(QEvent *event)
+{
+    // On Wayland, the workaround related to mDesktopChanged does not make sense because
+    // we cannot activate any window. So, we just hide the window on deactivation.
+    if (event->type() == QEvent::WindowDeactivate && QGuiApplication::platformName() != QSL("xcb"))
+    {
+        hide();
+    }
+    return QDialog::event(event);
+}
+
 #undef DEFAULT_SHORTCUT

--- a/dialog.h
+++ b/dialog.h
@@ -70,6 +70,7 @@ protected:
     bool eventFilter(QObject *object, QEvent *event);
     bool editKeyPressEvent(QKeyEvent *event);
     bool listKeyPressEvent(QKeyEvent *event);
+    bool event(QEvent *event);
 
 private:
     Ui::Dialog *ui;


### PR DESCRIPTION
The workaround of the code for problems with some X11 WMs needs `KX11Extras`, which does nothing on Wayland. Hence the patch for Wayland.

On the other hand, at least LabWC doesn't have any problem in this regard, and since Wayland compositors are completely responsible for activation/deactivation, we can consider probable problems as bugs in them.