### PR TITLE
Added scope=launcher

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -214,6 +214,7 @@ void Dialog::showEvent(QShowEvent *event)
                 layershell->setLayer(LayerShellQt::Window::Layer::LayerTop);
                 layershell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
                 LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop};
+                layershell->setScope(QStringLiteral("launcher"));
                 layershell->setAnchors(anchors);
 
                 QScreen *screen = nullptr;


### PR DESCRIPTION
We have set scope in all (`lxqt-leave` has "window" afaik) layershell applications:
```
$ hyprctl layers
Monitor eDP-1:
        Layer level 0 (background):
                Layer 649ee26d0d20: xywh: 0 0 1920 1080, namespace: desktop
        Layer level 1 (bottom):
        Layer level 2 (top):
                Layer 649ee264de10: xywh: 0 0 1920 48, namespace: dock
                Layer 649ee14f4600: xywh: 1877 235 43 658, namespace: dock
                Layer 649ee23d0f20: xywh: 161 1037 1555 43, namespace: dock
                Layer 649ee125faf0: xywh: 688.5 267 500 46, namespace: launcher
        Layer level 3 (overlay):
                Layer 649ee2876ff0: xywh: 1341 50 534 89, namespace: notification

```
It makes it possible to add layer rules in compositor which support them, for example 
```
layerrule = noanim, launcher
layerrule = dimaround, launcher
```
