### PR TITLE
Suppress Qt warnings for invalid QRegularExpression

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -546,7 +546,8 @@ void Dialog::setFilter(const QString &text, bool onlyHistory)
     QString trimmedText = text.simplified();
     mCommandItemModel->setCommand(trimmedText);
     mCommandItemModel->showOnlyHistory(onlyHistory);
-    mCommandItemModel->setFilterRegularExpression(trimmedText);
+    QRegularExpression regExp(trimmedText);
+    mCommandItemModel->setFilterRegularExpression(regExp.isValid() ? regExp : QRegularExpression());
     mCommandItemModel->invalidate();
 
     // tidy up layout and select first item

--- a/providers.cpp
+++ b/providers.cpp
@@ -268,7 +268,7 @@ bool AppLinkItem::run() const
  ************************************************/
 bool AppLinkItem::compare(const QRegularExpression &regExp) const
 {
-    if (regExp.pattern().isEmpty())
+    if (!regExp.isValid() || regExp.pattern().isEmpty())
         return false;
 
     return mProgram.contains(regExp)
@@ -461,7 +461,7 @@ bool HistoryItem::run() const
  ************************************************/
 bool HistoryItem::compare(const QRegularExpression &regExp) const
 {
-    return mCommand.contains(regExp);
+    return regExp.isValid() && mCommand.contains(regExp);
 }
 
 
@@ -638,7 +638,7 @@ bool VirtualBoxItem::run() const
 
 bool VirtualBoxItem::compare(const QRegularExpression &regExp) const
 {
-    return (!regExp.pattern().isEmpty() && -1 != title().indexOf(regExp));
+    return (regExp.isValid() && !regExp.pattern().isEmpty() && -1 != title().indexOf(regExp));
 }
 
 unsigned int VirtualBoxItem::rank(const QString &pattern) const
@@ -876,6 +876,9 @@ bool MathItem::run() const
  ************************************************/
 bool MathItem::compare(const QRegularExpression &regExp) const
 {
+    if (!regExp.isValid())
+        return false;
+
     QString s = regExp.pattern().trimmed();
 
     bool is_math = false;

--- a/providers.cpp
+++ b/providers.cpp
@@ -268,7 +268,7 @@ bool AppLinkItem::run() const
  ************************************************/
 bool AppLinkItem::compare(const QRegularExpression &regExp) const
 {
-    if (!regExp.isValid() || regExp.pattern().isEmpty())
+    if (regExp.pattern().isEmpty())
         return false;
 
     return mProgram.contains(regExp)
@@ -461,7 +461,7 @@ bool HistoryItem::run() const
  ************************************************/
 bool HistoryItem::compare(const QRegularExpression &regExp) const
 {
-    return regExp.isValid() && mCommand.contains(regExp);
+    return mCommand.contains(regExp);
 }
 
 
@@ -638,7 +638,7 @@ bool VirtualBoxItem::run() const
 
 bool VirtualBoxItem::compare(const QRegularExpression &regExp) const
 {
-    return (regExp.isValid() && !regExp.pattern().isEmpty() && -1 != title().indexOf(regExp));
+    return (!regExp.pattern().isEmpty() && -1 != title().indexOf(regExp));
 }
 
 unsigned int VirtualBoxItem::rank(const QString &pattern) const
@@ -876,9 +876,6 @@ bool MathItem::run() const
  ************************************************/
 bool MathItem::compare(const QRegularExpression &regExp) const
 {
-    if (!regExp.isValid())
-        return false;
-
     QString s = regExp.pattern().trimmed();
 
     bool is_math = false;


### PR DESCRIPTION
Previously when entering math and other expressions that were not valid QRegularExpression's, lxqt-runner would spam hundreds of Qt warnings that could be seen from the command line or journalctl.