### PR TITLE
Set the width by percentage on Wayland (in config dialog)

### DIFF
--- a/configuredialog/configuredialog.cpp
+++ b/configuredialog/configuredialog.cpp
@@ -62,6 +62,17 @@ ConfigureDialog::ConfigureDialog(QSettings *settings, const QString &defaultShor
     ui->positionCbx->addItem(tr("Center of the screen"), QVariant(ConfigureDialog::PositionCenter));
     connect(ui->positionCbx, &QComboBox::currentIndexChanged, this, &ConfigureDialog::positionCbxChanged);
 
+    // Width ....................................
+    if (QGuiApplication::platformName() == QSL("wayland"))
+    {
+        connect(ui->widthSB, &QAbstractSpinBox::editingFinished, this, [this] { mSettings->setValue(QL1S("dialog/wayland_width"), ui->widthSB->value()); });
+    }
+    else
+    {
+        ui->widthLabel->hide();
+        ui->widthSB->hide();
+    }
+
     // Monitor ..................................
 
     ui->monitorCbx->addItem(tr("Focused screen"), QVariant(-1));
@@ -94,6 +105,8 @@ ConfigureDialog::ConfigureDialog(QSettings *settings, const QString &defaultShor
  ************************************************/
 void ConfigureDialog::settingsChanged()
 {
+    ui->widthSB->setValue(mSettings->value(QL1S("dialog/wayland_width")).toInt());
+
     if (mSettings->value(QL1S("dialog/show_on_top"), true).toBool())
     {
         ui->positionCbx->setCurrentIndex(0);

--- a/configuredialog/configuredialog.ui
+++ b/configuredialog/configuredialog.ui
@@ -45,30 +45,33 @@
        </widget>
       </item>
       <item row="2" column="0">
+       <widget class="QLabel" name="widthLabel">
+        <property name="text">
+         <string>Width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="widthSB">
+        <property name="suffix">
+         <string>%</string>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Show on:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="monitorCbx"/>
       </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="historyFirstCb">
-        <property name="text">
-         <string>Show history first</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="historyUseCb">
-        <property name="text">
-         <string>Store/show history</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_4">
         <property name="toolTip">
          <string>&lt;b&gt;Note&lt;/b&gt;: The size of top-level widgets are constrained to 2/3 of the desktop's height and width.</string>
@@ -78,7 +81,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QSpinBox" name="listShownItemsSB">
         <property name="suffix">
          <string> item(s)</string>
@@ -88,7 +91,21 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="historyUseCb">
+        <property name="text">
+         <string>Store/show history</string>
+        </property>
+       </widget>
+      </item>
       <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="historyFirstCb">
+        <property name="text">
+         <string>Show history first</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="clearCb">
         <property name="text">
          <string>Clear input on launching</string>

--- a/dialog.h
+++ b/dialog.h
@@ -82,6 +82,7 @@ private:
     bool mClearOnRunning;
     int mMonitor;
     QString mScreenName;
+    int mWaylandWidth;
     LXQt::PowerManager *mPowerManager;
     LXQt::ScreenSaver *mScreenSaver;
 


### PR DESCRIPTION
… because window resizing is erratic with Wayland anchors (actually, it should have been disabled in the direction of anchors).

The compositor may change the mouse cursor to the resizing cursor, but the patch prevents resizing (even if it was resized, its configured size would be restored the next time it was shown).

X11 is kept intact.

Closes https://github.com/lxqt/lxqt-runner/issues/287