### PR TITLE
Best positioning of lxqt-runner with multi-screen Wayland

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -48,10 +48,10 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.process(a);
 
-    std::shared_ptr<QWidget> hiddenPreviewParent;
-    if (QGuiApplication::platformName() != QSL("wayland"))
-        hiddenPreviewParent = std::make_shared<QWidget>(nullptr, Qt::Tool);
-    Dialog d(hiddenPreviewParent.get());
+    // NOTE: At least on Wayland, and with some compositors, a hidden parent
+    // is needed for the dialog to appear on the screen that is set for it.
+    QWidget hiddenPreviewParent{0, Qt::Tool};
+    Dialog d(&hiddenPreviewParent);
     a.setActivationWindow(&d);
 
     return a.exec();


### PR DESCRIPTION
There is a detailed comment in the code, but in short,

 * There is no Qt way for knowing the Wayland screen with the cursor. As a result, the size and vertical position of lxqt-runner (in case it's supposed to be centered vertically) are calculated and correct only relative to the smallest screen (which is usually the one with the largest scale factor). This means that the widget is wider than expected and above the center of another screen.
 * Also, https://github.com/lxqt/lxqt-runner/commit/b0cad7975f5806bcd238f2d4285b5998a9857fb7 is reversed because, at least on KWin, the screen of lxqt-runner doesn't change without a hidden parent — don't ask me why, but perhaps the X11 developers encountered a similar issue.

NOTE: So far, this compromise is the only way — until Qt provides better Wayland methods. Take it or leave it ;)