### PR TITLE
Be more explicit about X11

### DIFF
--- a/dialog.cpp
+++ b/dialog.cpp
@@ -287,7 +287,7 @@ void Dialog::showEvent(QShowEvent *event)
             }
         }
     }
-    else
+    else if (QGuiApplication::platformName() == QSL("xcb"))
     {
         connect(KX11Extras::self(), &KX11Extras::activeWindowChanged, this, &Dialog::onActiveWindowChanged);
         connect(KX11Extras::self(), &KX11Extras::currentDesktopChanged, this, &Dialog::onCurrentDesktopChanged);


### PR DESCRIPTION
Although we're either on X11 or on Wayland and this change makes no difference in practice, logically it's better to be explicit about X11 in one case, where slots are connected and disconnected.